### PR TITLE
fix(utils): correct clsx default import (fixes #19)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,8 @@
-import { clsx } from "clsx";
-import { twMerge } from "tailwind-merge"
+// Correct default import for clsx (issue #19)
+import clsx from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs) {
+  // clsx expects a spread/array; passing rest args directly
   return twMerge(clsx(inputs));
 }


### PR DESCRIPTION
### PR: fix(utils): correct clsx default import (fixes #19)

## Summary
Fix incorrect named import of `clsx` in `lib/utils.js` causing `TypeError: clsx is not a function` when `cn()` is used.

## Root Cause
`clsx` is a default export; using a named import returned `undefined`.

## Change
```diff
- import { clsx } from "clsx";
- import { twMerge } from "tailwind-merge"
+ import clsx from "clsx";
+ import { twMerge } from "tailwind-merge";