### PR TITLE
fix(cover-letter): verify ownership then delete by id (fixes #21)

### DIFF
--- a/action/cover-letter.js
+++ b/action/cover-letter.js
@@ -95,7 +95,8 @@ export async function getCoverLetter(id) {
 
   if (!user) throw new Error("User not found");
 
-  return await db.coverLetter.findUnique({
+  // Adjusted in issue #20 branch (ensure filtering by both id and user ownership)
+  return await db.coverLetter.findFirst({
     where: {
       id,
       userId: user.id,
@@ -113,10 +114,10 @@ export async function deleteCoverLetter(id) {
 
   if (!user) throw new Error("User not found");
 
-  return await db.coverLetter.delete({
-    where: {
-      id,
-      userId: user.id,
-    },
-  });
+  // Issue #21: delete() must use a unique selector; verify ownership first then delete by id
+  const letter = await db.coverLetter.findUnique({ where: { id } });
+  if (!letter || letter.userId !== user.id) {
+    throw new Error("Not found");
+  }
+  return await db.coverLetter.delete({ where: { id } });
 }


### PR DESCRIPTION
- return await db.coverLetter.delete({
-   where: { id, userId: user.id },
- });
+ const letter = await db.coverLetter.findUnique({ where: { id } });
+ if (!letter || letter.userId !== user.id) {
+   throw new Error("Not found");
+ }
+ return await db.coverLetter.delete({ where: { id } });